### PR TITLE
Substitui vírgula por ponto

### DIFF
--- a/frontend/src/pages/CalcRendimento/CalcRendimento.jsx
+++ b/frontend/src/pages/CalcRendimento/CalcRendimento.jsx
@@ -20,8 +20,8 @@ const CalcRendimento = () => {
   const calcPrice = (e) => {
     e.preventDefault();
     try {
-      const alc = parseFloat(etanol);
-      const gas = parseFloat(gasolina);
+      const alc = parseFloat(etanol.replace(',', '.'));
+      const gas = parseFloat(gasolina.replace(',', '.'));
 
       if ((gas <= 0) && (alc <= 0)) {
         toast.error('Valor da gasolina e etanol inválidos. Informe um valor maior que zero.', {


### PR DESCRIPTION
Ao clicar no botão de 'Calcular', a conversão de `string` para `float` estava ocorrendo de forma errada, mesmo inserindo valores decimais, ele estava arredondando e o resultado final era equivalente a um número inteiro, ignorando os 'centavos', resultando em valores errado no cálculo. Com a alteração proposta, a vírgula é substituída por ponto e, dessa forma, o método `parseFloat` reconhece o valor como decimal. 